### PR TITLE
Fix false free-parking near intersections

### DIFF
--- a/montreal_parking/constants.py
+++ b/montreal_parking/constants.py
@@ -12,6 +12,9 @@ CRS_MTM8 = "EPSG:32188"  # NAD83 MTM zone 8, metric CRS for Montreal
 
 MAX_SNAP_DISTANCE_M = 20.0
 
+# Edge intervals shorter than this are too close to an intersection to be free parking
+MIN_FREE_EDGE_M = 5.0
+
 URLS = {
     "signage": (
         "https://donnees.montreal.ca/dataset/"

--- a/montreal_parking/intervals.py
+++ b/montreal_parking/intervals.py
@@ -8,7 +8,7 @@ import geopandas as gpd
 import pandas as pd
 from shapely.ops import substring
 
-from montreal_parking.constants import CRS_MTM8
+from montreal_parking.constants import CRS_MTM8, MIN_FREE_EDGE_M
 
 
 def _get_signs_for_direction(
@@ -93,6 +93,9 @@ def _build_side_intervals(
     first_dist = first_pole["projection_distance"]
     if first_dist > 1.0:
         cat, descs = _classify_interval(_get(first_id, "backward"))
+        # Short edges near intersections can't be free parking
+        if cat == "free" and first_dist < MIN_FREE_EDGE_M:
+            cat = "no_data"
         iv = _make_interval(0, first_dist, cat, descs, road_geom, id_trc, side, street_name)
         if iv:
             intervals.append(iv)
@@ -114,8 +117,12 @@ def _build_side_intervals(
     last_pole = pole_data.iloc[-1]
     last_id = last_pole["POTEAU_ID_POT"]
     last_dist = last_pole["projection_distance"]
-    if road_geom.length - last_dist > 1.0:
+    tail_length = road_geom.length - last_dist
+    if tail_length > 1.0:
         cat, descs = _classify_interval(_get(last_id, "forward"))
+        # Short edges near intersections can't be free parking
+        if cat == "free" and tail_length < MIN_FREE_EDGE_M:
+            cat = "no_data"
         iv = _make_interval(last_dist, road_geom.length, cat, descs, road_geom, id_trc, side, street_name)
         if iv:
             intervals.append(iv)

--- a/tests/test_intervals.py
+++ b/tests/test_intervals.py
@@ -344,3 +344,72 @@ class TestReconstructIntervals:
         right = intervals[intervals["side"] == "right"]
         # Both before and after the pole should be restricted (arrow 0 = both)
         assert all(right["category"] == "restricted")
+
+    def test_short_free_edge_becomes_no_data(self) -> None:
+        """A short (<5m) edge interval that would be 'free' should become 'no_data'.
+
+        This prevents false free-parking near intersections (e.g. Boyer/Généreux).
+        Pole at 3m with forward-only arrow: backward direction has no signs,
+        so the 0-3m edge would be classified 'free' — but it's too short.
+        """
+        roads = _make_road(length=100)
+        signs = _make_snapped_signs([{
+            "POTEAU_ID_POT": 1,
+            "projection_distance": 3.0,
+            "side": "right",
+            "ID_TRC": 1,
+            "DESCRIPTION_RPA": "\\P",
+            "FLECHE_PAN": 2,  # right side: 2=forward (points away from 0m edge)
+            "sign_category": "no_parking",
+            "is_restrictive": True,
+            "NOM_VOIE": "Rue Test",
+        }])
+        intervals = reconstruct_intervals(signs, roads)
+        right = intervals[intervals["side"] == "right"]
+        edge = right[right["start_dist"] == 0]
+        assert len(edge) == 1
+        assert edge.iloc[0]["category"] == "no_data"
+
+    def test_short_free_tail_becomes_no_data(self) -> None:
+        """A short (<5m) tail edge that would be 'free' should become 'no_data'."""
+        roads = _make_road(length=100)
+        # Pole at 97m with backward-only arrow: forward direction has no signs,
+        # so the 97-100m tail would be 'free' — but it's too short.
+        signs = _make_snapped_signs([{
+            "POTEAU_ID_POT": 1,
+            "projection_distance": 97.0,
+            "side": "right",
+            "ID_TRC": 1,
+            "DESCRIPTION_RPA": "\\P",
+            "FLECHE_PAN": 3,  # right side: 3=backward (points away from 100m edge)
+            "sign_category": "no_parking",
+            "is_restrictive": True,
+            "NOM_VOIE": "Rue Test",
+        }])
+        intervals = reconstruct_intervals(signs, roads)
+        right = intervals[intervals["side"] == "right"]
+        tail = right[right["end_dist"] >= 99]
+        assert len(tail) == 1
+        assert tail.iloc[0]["category"] == "no_data"
+
+    def test_long_free_edge_stays_free(self) -> None:
+        """A longer (>=5m) edge interval that's 'free' should remain free."""
+        roads = _make_road(length=100)
+        # Pole at 10m with forward-only arrow: backward has no signs,
+        # so edge 0-10m is 'free' and long enough to stay free.
+        signs = _make_snapped_signs([{
+            "POTEAU_ID_POT": 1,
+            "projection_distance": 10.0,
+            "side": "right",
+            "ID_TRC": 1,
+            "DESCRIPTION_RPA": "\\P",
+            "FLECHE_PAN": 2,  # right side: 2=forward (points away from 0m edge)
+            "sign_category": "no_parking",
+            "is_restrictive": True,
+            "NOM_VOIE": "Rue Test",
+        }])
+        intervals = reconstruct_intervals(signs, roads)
+        right = intervals[intervals["side"] == "right"]
+        edge = right[right["start_dist"] == 0]
+        assert len(edge) == 1
+        assert edge.iloc[0]["category"] == "free"


### PR DESCRIPTION
## Summary
- Edge intervals shorter than 5m that would be classified "free" are now "no_data"
- Fixes false green zones near intersections (e.g. Boyer/Généreux where poles 15064 and 241924 have outward arrows across a cross street)
- New constant `MIN_FREE_EDGE_M = 5.0` in `constants.py`

## Test plan
- [x] 3 new tests: short free edge → no_data, short free tail → no_data, long free edge stays free
- [x] All 56 tests pass, lint clean, typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)