### PR TITLE
Refactor: level-based interval classification

### DIFF
--- a/montreal_parking/classify.py
+++ b/montreal_parking/classify.py
@@ -66,7 +66,21 @@ def classify_sign(description: str) -> str:
 
 def is_restrictive(category: str) -> bool:
     """Whether a sign category prevents free parking."""
-    return category in ("no_parking", "permit", "paid")
+    return category in ("no_parking", "permit")
+
+
+def sign_level(category: str) -> int | None:
+    """Priority level for interval classification. Higher overrides lower.
+
+    Level 3: parking disallowed (no_parking, permit)
+    Level 4: parking allowed with conditions (time_limited, unrestricted, paid)
+    None: not used in interval classification (street_cleaning, panonceau, other)
+    """
+    if category in ("no_parking", "permit"):
+        return 3
+    if category in ("time_limited", "unrestricted", "paid"):
+        return 4
+    return None
 
 
 def classify_all_signs(df: pd.DataFrame) -> pd.DataFrame:

--- a/montreal_parking/constants.py
+++ b/montreal_parking/constants.py
@@ -46,6 +46,7 @@ FILENAMES = {
 COLOR_FREE = "#2ecc71"  # green
 COLOR_TIME_LIMITED = "#f1c40f"  # yellow
 COLOR_RESTRICTED = "#e74c3c"  # red
+COLOR_PAID = "#3498db"  # blue
 COLOR_NO_DATA = "#9b59b6"  # purple
 
 # Default map centre (Montreal city centre)

--- a/montreal_parking/intervals.py
+++ b/montreal_parking/intervals.py
@@ -8,6 +8,7 @@ import geopandas as gpd
 import pandas as pd
 from shapely.ops import substring
 
+from montreal_parking.classify import sign_level
 from montreal_parking.constants import CRS_MTM8, MIN_FREE_EDGE_M
 
 
@@ -23,16 +24,150 @@ def _get_signs_for_direction(
     return [s for s in pole_signs.get(pole_id, []) if s["arrow"] in (arrow, 0)]
 
 
-def _classify_interval(active_signs: list[dict[str, Any]]) -> tuple[str, list[Any]]:
-    """Classify an interval given its active signs."""
+def _classify_level_interval(
+    active_signs: list[dict[str, Any]],
+    level: int,
+) -> str | None:
+    """Classify an interval given its active signs at a specific level.
+
+    Level 3: if any sign is restrictive -> "restricted", else None
+    Level 4: "paid" > "time_limited" > "free" (unrestricted)
+    Returns None if no signs contribute a classification.
+    """
     if not active_signs:
-        return "free", []
-    has_restrictive = any(s["is_restrictive"] for s in active_signs)
-    if has_restrictive:
-        return "restricted", [s["description"] for s in active_signs]
-    if any(s["category"] == "time_limited" for s in active_signs):
-        return "time_limited", [s["description"] for s in active_signs]
-    return "free", [s["description"] for s in active_signs]
+        return None
+    if level == 3:
+        if any(s["category"] in ("no_parking", "permit") for s in active_signs):
+            return "restricted"
+        return None
+    if level == 4:
+        categories = {s["category"] for s in active_signs}
+        if "paid" in categories:
+            return "paid"
+        if "time_limited" in categories:
+            return "time_limited"
+        if "unrestricted" in categories:
+            return "free"
+    return None
+
+
+def _walk_level_spans(
+    pole_data: pd.DataFrame,
+    pole_signs: dict[Any, list[dict[str, Any]]],
+    forward_arrow: int,
+    backward_arrow: int,
+    road_length: float,
+    level: int,
+) -> list[tuple[float, float, str]]:
+    """Walk poles at a given level and produce classified spans.
+
+    Returns list of (start, end, category) spans. Only poles that have at least
+    one sign at this level are included in pole_data.
+    """
+    if pole_data.empty:
+        return []
+
+    spans: list[tuple[float, float, str]] = []
+
+    def _get(pole_id: Any, direction: str) -> list[dict[str, Any]]:
+        return _get_signs_for_direction(
+            pole_id, direction, pole_signs, forward_arrow, backward_arrow,
+        )
+
+    # Edge interval before first pole
+    first_pole = pole_data.iloc[0]
+    first_id = first_pole["POTEAU_ID_POT"]
+    first_dist = float(first_pole["projection_distance"])
+    if first_dist > 1.0:
+        cat = _classify_level_interval(_get(first_id, "backward"), level)
+        if cat is not None:
+            spans.append((0, first_dist, cat))
+
+    # Intervals between consecutive poles
+    for i in range(len(pole_data) - 1):
+        p1 = pole_data.iloc[i]
+        p2 = pole_data.iloc[i + 1]
+        active = _get(p1["POTEAU_ID_POT"], "forward") + _get(p2["POTEAU_ID_POT"], "backward")
+        cat = _classify_level_interval(active, level)
+        if cat is not None:
+            spans.append((
+                float(p1["projection_distance"]),
+                float(p2["projection_distance"]),
+                cat,
+            ))
+
+    # Edge interval after last pole
+    last_pole = pole_data.iloc[-1]
+    last_id = last_pole["POTEAU_ID_POT"]
+    last_dist = float(last_pole["projection_distance"])
+    if road_length - last_dist > 1.0:
+        cat = _classify_level_interval(_get(last_id, "forward"), level)
+        if cat is not None:
+            spans.append((last_dist, road_length, cat))
+
+    return spans
+
+
+def _merge_level_spans(
+    level3_spans: list[tuple[float, float, str]],
+    level4_spans: list[tuple[float, float, str]],
+    road_length: float,
+) -> list[tuple[float, float, str, list[str]]]:
+    """Merge level 3 and level 4 spans. Level 4 overrides level 3; level 3 overrides default (free).
+
+    Returns list of (start, end, category, descriptions) tuples covering [0, road_length].
+    """
+    # Collect all boundary points
+    boundaries: set[float] = {0.0, road_length}
+    for spans in (level3_spans, level4_spans):
+        for start, end, _ in spans:
+            boundaries.add(start)
+            boundaries.add(end)
+    sorted_bounds = sorted(boundaries)
+
+    result: list[tuple[float, float, str, list[str]]] = []
+    for i in range(len(sorted_bounds) - 1):
+        seg_start = sorted_bounds[i]
+        seg_end = sorted_bounds[i + 1]
+        if seg_end - seg_start < 0.5:
+            continue
+
+        mid = (seg_start + seg_end) / 2
+
+        # Find level 4 classification at midpoint
+        l4_cat: str | None = None
+        for start, end, cat in level4_spans:
+            if start <= mid < end:
+                l4_cat = cat
+                break
+
+        # Find level 3 classification at midpoint
+        l3_cat: str | None = None
+        for start, end, cat in level3_spans:
+            if start <= mid < end:
+                l3_cat = cat
+                break
+
+        # Level 4 overrides level 3, level 3 overrides default ("free")
+        if l4_cat is not None:
+            final_cat = l4_cat
+        elif l3_cat is not None:
+            final_cat = l3_cat
+        else:
+            final_cat = "free"
+
+        result.append((seg_start, seg_end, final_cat, []))
+
+    # Merge adjacent spans with the same category
+    merged: list[tuple[float, float, str, list[str]]] = []
+    for span in result:
+        if merged and merged[-1][2] == span[2]:
+            prev = merged[-1]
+            merged[-1] = (prev[0], span[1], prev[2], prev[3])
+        else:
+            merged.append(span)
+
+    return merged
 
 
 def _make_interval(
@@ -81,49 +216,51 @@ def _build_side_intervals(
     side: str,
     street_name: str,
 ) -> list[dict[str, Any]]:
-    """Build intervals for one (road, side) group from its poles."""
+    """Build intervals for one (road, side) group from its poles using level-based classification."""
+    road_length = road_geom.length
+
+    # Split pole_signs by level
+    level_pole_signs: dict[int, dict[Any, list[dict[str, Any]]]] = {3: {}, 4: {}}
+    for pid, signs in pole_signs.items():
+        for sign in signs:
+            lvl = sign_level(sign["category"])
+            if lvl in level_pole_signs:
+                if pid not in level_pole_signs[lvl]:
+                    level_pole_signs[lvl][pid] = []
+                level_pole_signs[lvl][pid].append(sign)
+
+    # Build pole DataFrames for each level (poles that have at least one sign at that level)
+    level_pole_data: dict[int, pd.DataFrame] = {}
+    for lvl in (3, 4):
+        level_pids = set(level_pole_signs[lvl].keys())
+        if level_pids:
+            mask = pole_data["POTEAU_ID_POT"].isin(level_pids)
+            level_pole_data[lvl] = pole_data[mask].reset_index(drop=True)
+        else:
+            level_pole_data[lvl] = pole_data.iloc[0:0]  # empty with same columns
+
+    # Walk each level independently
+    level3_spans = _walk_level_spans(
+        level_pole_data[3], level_pole_signs[3],
+        forward_arrow, backward_arrow, road_length, level=3,
+    )
+    level4_spans = _walk_level_spans(
+        level_pole_data[4], level_pole_signs[4],
+        forward_arrow, backward_arrow, road_length, level=4,
+    )
+
+    # Merge levels
+    merged = _merge_level_spans(level3_spans, level4_spans, road_length)
+
+    # Apply 5m edge rule and build geometry
     intervals: list[dict[str, Any]] = []
-
-    def _get(pole_id: Any, direction: str) -> list[dict[str, Any]]:
-        return _get_signs_for_direction(pole_id, direction, pole_signs, forward_arrow, backward_arrow)
-
-    # Edge interval before first pole
-    first_pole = pole_data.iloc[0]
-    first_id = first_pole["POTEAU_ID_POT"]
-    first_dist = first_pole["projection_distance"]
-    if first_dist > 1.0:
-        cat, descs = _classify_interval(_get(first_id, "backward"))
+    for start, end, cat, descs in merged:
         # Short edges near intersections can't be free parking
-        if cat == "free" and first_dist < MIN_FREE_EDGE_M:
+        if cat == "free" and start == 0.0 and end < MIN_FREE_EDGE_M:
             cat = "no_data"
-        iv = _make_interval(0, first_dist, cat, descs, road_geom, id_trc, side, street_name)
-        if iv:
-            intervals.append(iv)
-
-    # Intervals between consecutive poles
-    for i in range(len(pole_data) - 1):
-        p1 = pole_data.iloc[i]
-        p2 = pole_data.iloc[i + 1]
-        active = _get(p1["POTEAU_ID_POT"], "forward") + _get(p2["POTEAU_ID_POT"], "backward")
-        cat, descs = _classify_interval(active)
-        iv = _make_interval(
-            p1["projection_distance"], p2["projection_distance"],
-            cat, descs, road_geom, id_trc, side, street_name,
-        )
-        if iv:
-            intervals.append(iv)
-
-    # Edge interval after last pole
-    last_pole = pole_data.iloc[-1]
-    last_id = last_pole["POTEAU_ID_POT"]
-    last_dist = last_pole["projection_distance"]
-    tail_length = road_geom.length - last_dist
-    if tail_length > 1.0:
-        cat, descs = _classify_interval(_get(last_id, "forward"))
-        # Short edges near intersections can't be free parking
-        if cat == "free" and tail_length < MIN_FREE_EDGE_M:
+        if cat == "free" and end == road_length and (road_length - start) < MIN_FREE_EDGE_M:
             cat = "no_data"
-        iv = _make_interval(last_dist, road_geom.length, cat, descs, road_geom, id_trc, side, street_name)
+        iv = _make_interval(start, end, cat, descs, road_geom, id_trc, side, street_name)
         if iv:
             intervals.append(iv)
 
@@ -163,8 +300,11 @@ def reconstruct_intervals(
         )
 
         # Build lookup: pole_id -> list of sign info dicts
+        # Exclude street_cleaning from classification (kept in snapped data for popups)
         pole_signs: dict[Any, list[dict[str, Any]]] = {}
         for _, sign_row in group.iterrows():
+            if sign_row["sign_category"] == "street_cleaning":
+                continue
             pid = sign_row["POTEAU_ID_POT"]
             if pid not in pole_signs:
                 pole_signs[pid] = []

--- a/montreal_parking/map.py
+++ b/montreal_parking/map.py
@@ -15,6 +15,7 @@ import shapely
 from montreal_parking.constants import (
     COLOR_FREE,
     COLOR_NO_DATA,
+    COLOR_PAID,
     COLOR_RESTRICTED,
     COLOR_TIME_LIMITED,
     CRS_WGS84,
@@ -31,6 +32,7 @@ from montreal_parking.constants import (
 _LAYER_CONFIG: list[tuple[str, str, str, bool]] = [
     ("Free Parking", "free", COLOR_FREE, True),
     ("Time-Limited", "time_limited", COLOR_TIME_LIMITED, True),
+    ("Paid Parking", "paid", COLOR_PAID, True),
     ("Restricted", "restricted", COLOR_RESTRICTED, False),
     ("No Data", "no_data", COLOR_NO_DATA, False),
 ]

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import pytest
 
-from montreal_parking.classify import classify_sign, is_restrictive
+from montreal_parking.classify import classify_sign, is_restrictive, sign_level
 
 # ---------------------------------------------------------------------------
 # classify_sign
@@ -131,13 +131,34 @@ class TestClassifySign:
 class TestIsRestrictive:
     """is_restrictive should be True only for categories that block free parking."""
 
-    @pytest.mark.parametrize("category", ["no_parking", "permit", "paid"])
+    @pytest.mark.parametrize("category", ["no_parking", "permit"])
     def test_restrictive_categories(self, category: str) -> None:
         assert is_restrictive(category) is True
 
     @pytest.mark.parametrize(
         "category",
-        ["time_limited", "street_cleaning", "unrestricted", "panonceau", "other"],
+        ["paid", "time_limited", "street_cleaning", "unrestricted", "panonceau", "other"],
     )
     def test_non_restrictive_categories(self, category: str) -> None:
         assert is_restrictive(category) is False
+
+
+# ---------------------------------------------------------------------------
+# sign_level
+# ---------------------------------------------------------------------------
+
+
+class TestSignLevel:
+    """sign_level should return the correct priority level for each category."""
+
+    @pytest.mark.parametrize("category", ["no_parking", "permit"])
+    def test_level_3_categories(self, category: str) -> None:
+        assert sign_level(category) == 3
+
+    @pytest.mark.parametrize("category", ["time_limited", "unrestricted", "paid"])
+    def test_level_4_categories(self, category: str) -> None:
+        assert sign_level(category) == 4
+
+    @pytest.mark.parametrize("category", ["street_cleaning", "panonceau", "other"])
+    def test_none_categories(self, category: str) -> None:
+        assert sign_level(category) is None

--- a/tests/test_intervals.py
+++ b/tests/test_intervals.py
@@ -164,7 +164,10 @@ class TestReconstructIntervals:
         intervals = reconstruct_intervals(signs, roads)
         # Should have intervals on the right side (from signs) + no_data on left
         right_intervals = intervals[intervals["side"] == "right"]
-        assert len(right_intervals) == 2  # before + after the pole
+        # Level-based merge combines adjacent spans with the same category,
+        # so a single bidirectional no_parking pole produces one "restricted" interval
+        assert len(right_intervals) >= 1
+        assert all(right_intervals["category"] == "restricted")
 
     def test_two_restrictive_poles_creates_restricted_interval(self) -> None:
         """Two no-parking poles pointing inward → restricted interval between them."""
@@ -413,3 +416,184 @@ class TestReconstructIntervals:
         edge = right[right["start_dist"] == 0]
         assert len(edge) == 1
         assert edge.iloc[0]["category"] == "free"
+
+
+class TestLevelBasedClassification:
+    """Tests for the level-based interval classification system."""
+
+    def test_level4_overrides_level3(self) -> None:
+        """A time_limited (level 4) sign should override no_parking (level 3) in the same zone."""
+        roads = _make_road(length=100)
+        # Level 3: no_parking covers the whole road (bidirectional)
+        # Level 4: time_limited covers the whole road (bidirectional)
+        # Result: time_limited should win
+        signs = _make_snapped_signs([
+            {
+                "POTEAU_ID_POT": 1,
+                "projection_distance": 50.0,
+                "side": "right",
+                "ID_TRC": 1,
+                "DESCRIPTION_RPA": "\\P",
+                "FLECHE_PAN": 0,
+                "sign_category": "no_parking",
+                "is_restrictive": True,
+                "NOM_VOIE": "Rue Test",
+            },
+            {
+                "POTEAU_ID_POT": 1,
+                "projection_distance": 50.0,
+                "side": "right",
+                "ID_TRC": 1,
+                "DESCRIPTION_RPA": "P 15 MIN",
+                "FLECHE_PAN": 0,
+                "sign_category": "time_limited",
+                "is_restrictive": False,
+                "NOM_VOIE": "Rue Test",
+            },
+        ])
+        intervals = reconstruct_intervals(signs, roads)
+        right = intervals[intervals["side"] == "right"]
+        assert all(right["category"] == "time_limited")
+
+    def test_level3_arrows_dont_interact_with_level4(self) -> None:
+        """Level 3 arrows should only interact with level 3 arrows.
+
+        Scenario: level 3 no_parking with forward arrow, level 4 time_limited with backward arrow.
+        These should NOT create a combined restricted zone — they're at different levels.
+        """
+        roads = _make_road(length=100)
+        signs = _make_snapped_signs([
+            {
+                "POTEAU_ID_POT": 1,
+                "projection_distance": 20.0,
+                "side": "right",
+                "ID_TRC": 1,
+                "DESCRIPTION_RPA": "\\P",
+                "FLECHE_PAN": 2,  # forward
+                "sign_category": "no_parking",
+                "is_restrictive": True,
+                "NOM_VOIE": "Rue Test",
+            },
+            {
+                "POTEAU_ID_POT": 2,
+                "projection_distance": 80.0,
+                "side": "right",
+                "ID_TRC": 1,
+                "DESCRIPTION_RPA": "P 15 MIN",
+                "FLECHE_PAN": 3,  # backward
+                "sign_category": "time_limited",
+                "is_restrictive": False,
+                "NOM_VOIE": "Rue Test",
+            },
+        ])
+        intervals = reconstruct_intervals(signs, roads)
+        right = intervals[intervals["side"] == "right"]
+        # Level 3 forward from pole 1 covers 20-100m as "restricted"
+        # Level 4 backward from pole 2 covers 0-80m as "time_limited"
+        # Level 4 overrides level 3 in overlap (20-80m) → time_limited
+        # Final: time_limited [0,80], restricted [80,100]
+        tl = right[right["category"] == "time_limited"]
+        assert len(tl) >= 1
+        # The time_limited span should cover the overlap zone (20-80m)
+        assert tl.iloc[0]["start_dist"] <= 20.0
+        assert tl.iloc[0]["end_dist"] >= 80.0
+        # No "restricted" in the 20-80m zone
+        restricted_in_middle = right[
+            (right["category"] == "restricted")
+            & (right["start_dist"] < 80)
+            & (right["end_dist"] > 20)
+        ]
+        assert restricted_in_middle.empty
+
+    def test_paid_category_produces_paid_intervals(self) -> None:
+        """A paid parking sign should produce 'paid' intervals."""
+        roads = _make_road(length=100)
+        signs = _make_snapped_signs([{
+            "POTEAU_ID_POT": 1,
+            "projection_distance": 50.0,
+            "side": "right",
+            "ID_TRC": 1,
+            "DESCRIPTION_RPA": "TARIF 2$/HR",
+            "FLECHE_PAN": 0,
+            "sign_category": "paid",
+            "is_restrictive": False,
+            "NOM_VOIE": "Rue Test",
+        }])
+        intervals = reconstruct_intervals(signs, roads)
+        right = intervals[intervals["side"] == "right"]
+        assert all(right["category"] == "paid")
+
+    def test_street_cleaning_ignored_in_classification(self) -> None:
+        """Street cleaning signs should not affect interval classification."""
+        roads = _make_road(length=100)
+        signs = _make_snapped_signs([{
+            "POTEAU_ID_POT": 1,
+            "projection_distance": 50.0,
+            "side": "right",
+            "ID_TRC": 1,
+            "DESCRIPTION_RPA": "\\P 08h-09h MAR. 1 AVRIL AU 1 DEC.",
+            "FLECHE_PAN": 0,
+            "sign_category": "street_cleaning",
+            "is_restrictive": False,
+            "NOM_VOIE": "Rue Test",
+        }])
+        intervals = reconstruct_intervals(signs, roads)
+        right = intervals[intervals["side"] == "right"]
+        # Street cleaning is excluded from classification, so the road should be free
+        assert all(right["category"] == "free")
+
+    def test_deux_cotes_level3_doesnt_break_level4_zone(self) -> None:
+        r"""DEUX COTES copy (level 3) should not break a time_limited (level 4) zone.
+
+        This is the core bug that level-based classification fixes:
+        a DEUX COTES \P sign copied to the opposite side should not override
+        a P 15 MIN sign that's already there at level 4.
+        """
+        roads = _make_road(length=100)
+        signs = _make_snapped_signs([
+            # Level 4: time_limited sign on the right side
+            {
+                "POTEAU_ID_POT": 1,
+                "projection_distance": 30.0,
+                "side": "right",
+                "ID_TRC": 1,
+                "DESCRIPTION_RPA": "P 15 MIN",
+                "FLECHE_PAN": 2,  # forward
+                "sign_category": "time_limited",
+                "is_restrictive": False,
+                "NOM_VOIE": "Rue Test",
+            },
+            {
+                "POTEAU_ID_POT": 2,
+                "projection_distance": 70.0,
+                "side": "right",
+                "ID_TRC": 1,
+                "DESCRIPTION_RPA": "P 15 MIN",
+                "FLECHE_PAN": 3,  # backward
+                "sign_category": "time_limited",
+                "is_restrictive": False,
+                "NOM_VOIE": "Rue Test",
+            },
+            # Level 3: DEUX COTES copy in the middle of the time_limited zone
+            {
+                "POTEAU_ID_POT": 3,
+                "projection_distance": 50.0,
+                "side": "right",
+                "ID_TRC": 1,
+                "DESCRIPTION_RPA": "\\P DEUX COTES",
+                "FLECHE_PAN": 0,
+                "sign_category": "no_parking",
+                "is_restrictive": True,
+                "NOM_VOIE": "Rue Test",
+            },
+        ])
+        intervals = reconstruct_intervals(signs, roads)
+        right = intervals[intervals["side"] == "right"]
+        # The zone between poles 1 and 2 (30-70m) should be time_limited,
+        # NOT broken by the DEUX COTES copy
+        middle = right[
+            (right["start_dist"] >= 29) & (right["end_dist"] <= 71)
+        ]
+        cats = middle["category"].unique()
+        assert "time_limited" in cats, f"Expected time_limited in zone, got {cats}"
+        assert "restricted" not in cats, "DEUX COTES copy broke time_limited zone"


### PR DESCRIPTION
## Summary
- Introduces a priority-level system for interval classification: level 3 (no_parking, permit) and level 4 (time_limited, paid, unrestricted) are classified independently, with level 4 overriding level 3
- Fixes the bug where DEUX COTES copies (level 3) incorrectly broke time-limited zones (level 4) on the opposite side
- Adds `paid` as a distinct map layer (blue) and excludes `street_cleaning` from classification logic

## Key changes
| File | Change |
|------|--------|
| `constants.py` | Add `COLOR_PAID` |
| `classify.py` | Add `sign_level()`, remove `paid` from `is_restrictive()` |
| `intervals.py` | Rewrite to level-based: `_walk_level_spans()`, `_classify_level_interval()`, `_merge_level_spans()` |
| `map.py` | Add paid layer to `_LAYER_CONFIG` |
| `tests/test_classify.py` | Tests for `sign_level()`, updated `is_restrictive` tests |
| `tests/test_intervals.py` | Tests for level override, arrow isolation, paid intervals, street_cleaning exclusion, DEUX COTES fix |

## Test plan
- [x] `pixi run -e dev test` — 69 tests pass
- [x] `pixi run -e dev lint` — clean
- [x] `pixi run -e dev typecheck` — clean
- [x] `pixi run build-plateau` — builds successfully, 70 paid intervals (6.1 km)
- [ ] Check segment 1220059 left side: 156331→156332 zone should be `time_limited`
- [ ] Check Boyer/Généreux: short edges should be `no_data`

> **Note:** This PR is based on #4 (`perf-canvas-viewport-filtering`). Merge #4 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)