### PR TITLE
Add preview workflow for branch builds

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,34 @@
+name: Build Preview
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  build-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: prefix-dev/setup-pixi@v0.9.4
+
+      - name: Cache data downloads
+        uses: actions/cache@v5
+        with:
+          path: data/
+          key: montreal-data-${{ github.run_id }}
+          restore-keys: montreal-data-
+
+      - name: Build map (all Montreal)
+        run: pixi run build
+        env:
+          PYTHONUNBUFFERED: "1"
+
+      - name: Upload preview artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: map-preview-${{ github.ref_name }}
+          path: output/
+          retention-days: 7


### PR DESCRIPTION
## Summary
- Adds a `workflow_dispatch` workflow that builds the full map from any branch
- Uploads `output/` as a downloadable artifact (7-day retention)
- Allows previewing branch builds without needing Pages deploy permissions

## Usage
1. Go to Actions → "Build Preview" → Run workflow → select your branch
2. When complete, download the artifact zip from the run page
3. Unzip and open `index.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)