### PR TITLE
Add versioning (0.2.0)

### DIFF
--- a/montreal_parking/__init__.py
+++ b/montreal_parking/__init__.py
@@ -1,0 +1,23 @@
+"""Montreal Free Parking Finder."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib  # type: ignore[no-redef]
+
+_PIXI_TOML = Path(__file__).resolve().parent.parent / "pixi.toml"
+
+
+def _read_version() -> str:
+    try:
+        data = tomllib.loads(_PIXI_TOML.read_text())
+        return str(data["workspace"]["version"])
+    except Exception:
+        return "unknown"
+
+
+__version__: str = _read_version()

--- a/montreal_parking/map.py
+++ b/montreal_parking/map.py
@@ -12,6 +12,7 @@ import numpy as np
 import pandas as pd
 import shapely
 
+from montreal_parking import __version__
 from montreal_parking.constants import (
     COLOR_FREE,
     COLOR_NO_DATA,
@@ -402,7 +403,8 @@ def _build_html_shell(
         'Hobby project \u2014 not official. Data may be inaccurate.<br>' +
         '<a href="stats.html">Statistics</a>' +
         ' · <a href="https://github.com/yfarjoun/montreal-parking" target="_blank">GitHub</a>' +
-        ' · <a href="https://github.com/yfarjoun/montreal-parking/issues" target="_blank">Report a bug</a>';
+        ' · <a href="https://github.com/yfarjoun/montreal-parking/issues" target="_blank">Report a bug</a>' +
+        '<br><span style="color:#aaa;font-size:10px">v{__version__}</span>';
       return div;
     }};
     infoControl.addTo(map);

--- a/montreal_parking/stats.py
+++ b/montreal_parking/stats.py
@@ -9,6 +9,7 @@ from typing import Any
 import geopandas as gpd
 import pandas as pd
 
+from montreal_parking import __version__
 from montreal_parking.constants import (
     COLOR_FREE,
     COLOR_NO_DATA,
@@ -210,6 +211,7 @@ def generate_stats_html(
     Hobby project &mdash; not official. Data from
     <a href="https://donnees.montreal.ca/">Montreal Open Data</a>.
     <a href="https://github.com/yfarjoun/montreal-parking">GitHub</a>
+    &middot; v{__version__}
   </p>
   <script data-goatcounter="https://yfarjoun.goatcounter.com/count"
           async src="//gc.zgo.at/count.js"></script>

--- a/pixi.toml
+++ b/pixi.toml
@@ -3,7 +3,7 @@ authors = ["Yossi Farjoun <yossi@fulcrumgenomics.com>"]
 channels = ["conda-forge"]
 name = "montreal_parking"
 platforms = ["osx-arm64", "linux-64"]
-version = "0.1.0"
+version = "0.2.0"
 
 [dependencies]
 pandas = ">=3.0.1,<4"


### PR DESCRIPTION
## Summary
- Bump version to 0.2.0 in pixi.toml
- Add `montreal_parking.__version__` that reads from pixi.toml at runtime (single source of truth)
- Display version in map info box and stats page footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)